### PR TITLE
Fix resetting values of fields in conditionals

### DIFF
--- a/formbar/static/js/formbar.js
+++ b/formbar/static/js/formbar.js
@@ -526,7 +526,9 @@ var form = function (inputFilter, ruleEngine) {
                 if (!field.value) activateDesired(fieldName);
             }
             if (result == false && oldState == "active") {
-                clearFieldValue(fieldName);
+                if (div.attr("reset-value") == "true") {
+                    clearFieldValue(fieldName);
+                }
                 $("[name='"+fieldName+"']").map(function(i,x){ if (x.type==='text' || x.tagName==='TEXTAREA') x.setAttribute("readonly","readonly"); })
                 newState = "inactive";
                 deactivateDesired(fieldName);


### PR DESCRIPTION
Only reset field values if conditional accordingly configured using the
"reset-value" attribute.

Saw that field got reseted no matter what the configuration of the conditional was. See http://formbar.readthedocs.io/en/latest/config.html#conditional

@ThomasJunk do you expect any sideeffects?
