### PR TITLE
Simplify formbar/config.py(handle_entity_prefix)

### DIFF
--- a/formbar/config.py
+++ b/formbar/config.py
@@ -185,14 +185,11 @@ def handle_entity_prefix(tree, prefix):
         if n.tag == "entity":
             # Handle fields
             n.attrib["name"] = prefix + n.attrib["name"]
-        elif n.tag == "rule":
-            # Handle rules
+        elif n.tag in ("rule", "if"):
+            # Handle rules and conditionals
             n.attrib["expr"] = _var_re.sub(replace_fieldnames,
                                            n.attrib["expr"])
-        elif n.tag == "if":
-            # Handle conditional
-            n.attrib["expr"] = _var_re.sub(replace_fieldnames,
-                                           n.attrib["expr"])
+
     return tree
 
 


### PR DESCRIPTION
The reasoning in this function is too complex.
Simply use the re.sub() function instead of the
sorting and the iterated use of the str.replace() function.

Pull the compilation of the regular expression out
of the inner loop to a global as it never changes.

Allow '-' in variable names like brabbel does.

Only run once over the tree to avoid three expensive
findall calls.